### PR TITLE
Change castle color from bright white to white

### DIFF
--- a/asciiquarium
+++ b/asciiquarium
@@ -421,7 +421,7 @@ q{
         color         => \@castle_mask,
         position      => [ $anim->width() - 32, $anim->height() - 13, $depth{'castle'} ],
         callback_args => [ 0, 0, 0, 0.1],
-        default_color => 'WHITE',
+        default_color => 'white',
     );
 }
 


### PR DESCRIPTION
This PR changes the castle color from bright white to white.
In the original asciiquarium <https://robobunny.com/projects/asciiquarium/html/> the castle looked gray.