### PR TITLE
Prevent 'hook_point' from dropping 1 more row than 'fishhook'

### DIFF
--- a/asciiquarium
+++ b/asciiquarium
@@ -1157,7 +1157,7 @@ sub add_fishhook {
 .
 
 \
-
+?
 };
     my $line_image = "|\n" x 50 . " \n" x 6;
 

--- a/asciiquarium
+++ b/asciiquarium
@@ -421,7 +421,7 @@ q{
         color         => \@castle_mask,
         position      => [ $anim->width() - 32, $anim->height() - 13, $depth{'castle'} ],
         callback_args => [ 0, 0, 0, 0.1],
-        default_color => 'WHITE',
+        default_color => 'white',
     );
 }
 


### PR DESCRIPTION
This equation should be true.
`fishhook.height + fishhook.position[1] == hook_point.height + hook_point.position[1]`

Trailing newlines are stripped from the `hook_point` shape, so to increase the height, make the last row non-empty.

Before:
```
       |
       |
       o
      ||
      ||
/.\   ||
  \__//
 \`--'
```

After:
```
       |
       |
       o
      ||
 .    ||
/ \   ||
 \\__//
  `--'
```